### PR TITLE
Pin image to v2.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/apicurio/apicurio-registry-sql:latest-release
+FROM quay.io/apicurio/apicurio-registry-sql:2.3.1.Final
 
 ADD run .s2i/bin/run
 


### PR DESCRIPTION
Quarkus doesn't support the latest version yet so we need to pin this to v2.3.1.